### PR TITLE
updated to use an Element class containing type, rune and position

### DIFF
--- a/cmd/flatland-term/main.go
+++ b/cmd/flatland-term/main.go
@@ -28,6 +28,7 @@ func getRandomDirection(exclusion string) (direction string, err error) {
 		// run this puppy until it comes back with a direction that isn't the exclusion
 		// Hacky as hell, but is simple for now
 		if direction != exclusion {
+			fmt.Printf("exclusion[%s] index[%d] direction[%s]", exclusion, randomIndex, direction)
 			return direction, nil
 		}
 	}
@@ -35,19 +36,18 @@ func getRandomDirection(exclusion string) (direction string, err error) {
 
 func main() {
 	// Create a new WorldMap instance with dimensions 40x10
-	worldMap := worldmap.NewWorldMap(200, 60)
+	worldMap := worldmap.NewWorldMap(10, 10)
 
-	ox, y := 0, 5
-	worldMap.Put(ox, y, "*")
+	playerOne := worldmap.NewElement("Player One", "*", worldmap.Point{X: worldMap.Size.X / 2, Y: worldMap.Size.Y / 2})
 
 	// Move an element across the map
 	var err error
 	direction := worldmap.RIGHT
 	var isEdge bool
 	var edgeType string
-	for x := ox; x < worldMap.Width; {
+	for x := playerOne.Position.X; x < worldMap.Size.X; {
 
-		isEdge, edgeType = worldMap.IsMapEdge(x, y)
+		isEdge, edgeType = worldMap.IsMapEdge(playerOne.Position)
 
 		if isEdge {
 			switch edgeType {
@@ -64,11 +64,9 @@ func main() {
 				fmt.Println(err)
 				return
 			}
-
-			getRandomDirection(worldmap.LEFT) // test
 		}
 
-		x, y, err = worldMap.Move(x, y, direction)
+		_, err := worldMap.Move(playerOne, direction)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
 			break

--- a/internal/element.go
+++ b/internal/element.go
@@ -1,6 +1,37 @@
 package worldmap
 
+type Point struct {
+	X uint32
+	Y uint32
+}
+
 type Element struct {
 	Name           string
 	Representation string
+	Position       *Point
+}
+
+func NewElement(name, representation string, position Point) *Element {
+	return &Element{
+		Name:           name,
+		Representation: representation,
+		Position:       &position,
+	}
+}
+
+func (el *Element) SetPosition(x, y uint32) *Element {
+	el.Position.X = x
+	el.Position.Y = y
+	return el
+}
+
+func (el *Element) hasPosition() bool {
+	if el.Position == nil {
+		return false
+	}
+	return true
+}
+
+func (el *Element) String() string {
+	return el.Representation
 }


### PR DESCRIPTION
```refactored to use an element object instead of simple strings and x,y coordinates.  This should make the code more readable and reduce errors due to the x,y being reversed when manipulating the matrix.   i.e matrix[y][x]

replacing strings with structs may have memory and performance impacts that should be investigated.   

there is also still a known bug where the edges of the matrix aren't properly recognized

the random direction function is still a nasty little hack